### PR TITLE
Reset sign-in state (and button label) after successful login or login failure

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -69,6 +69,7 @@ export default class DigitsButton extends Component {
 
   handleLogin(loginResponse) {
     this.props.onLogin(loginResponse)
+    this.setState({ signingIn: false })
   }
 
   handleLoginFailure(loginResponse) {

--- a/src/index.js
+++ b/src/index.js
@@ -72,6 +72,7 @@ export default class DigitsButton extends Component {
   }
 
   handleLoginFailure(loginResponse) {
+    this.setState({ signingIn: false })
     this.props.onLoginFailure(loginResponse)
   }
 


### PR DESCRIPTION
If you don't do this and the login fails, it keeps the button disabled so that you can't attempt to login again without a page refresh.
